### PR TITLE
Anchoring on FAQ works better now; still imperfect for first elem.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+standardhealthrecord.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-standardhealthrecord.org

--- a/_scss/_banner_dev_1.scss
+++ b/_scss/_banner_dev_1.scss
@@ -1,5 +1,3 @@
-$banner-size-with-padding: 90px;
-$banner-size: 80px;
 
 .navbar-toggle {
     padding: 5px;

--- a/_scss/_layout_dev.scss
+++ b/_scss/_layout_dev.scss
@@ -11,7 +11,11 @@ $md-font-size:$base-font-size*1.25;
 $lg-font-size:$base-font-size*1.8;
 $xl-font-size:$base-font-size*2.2;
 $xxl-font-size:$base-font-size*2.6;
+
 $footer-height: 90px;
+$banner-size-with-padding: 90px;
+$navbar-max-height: 50px;
+$banner-size: 80px;
 
 $head-font-family: 'Gill Sans', 'Gill Sans MT', Lato, Helvetica, Arial, sans-serif;
 $base-font-family: 'Gill Sans Light', 'Gill Sans MT Light', Lato, Helvetica, Arial, sans-serif;
@@ -281,23 +285,24 @@ ul.reqs {
   li:last-child {border-bottom:0;}
 }
 .group{
-margin-top:100px;
-align:auto;
-.feedback {
- .btn-feedback{
-  margin-top:50px;
-  padding: 10px 16px;
-  font-size: 18px;
-  line-height: 1.3333333;
-  border-radius: 6px;
-  color:#fff;
-  background-color:$hero-color;
-  border-color:$hero-color;
-}}
+  margin-top:100px;
+  align:auto;
+  .feedback {
+    .btn-feedback{
+      margin-top:50px;
+      padding: 10px 16px;
+      font-size: 18px;
+      line-height: 1.3333333;
+      border-radius: 6px;
+      color:#fff;
+      background-color:$hero-color;
+      border-color:$hero-color;
+    }
+   }
 }
 
 section.faq {
-  h2.side-nav-title {padding-top:40px;margin-top:0px}
+  h2.side-nav-title {padding-top:10px;margin-top:0px}
   .side-nav {
     width:360px;
     &.affix {
@@ -317,13 +322,18 @@ section.faq {
   li {
     font-family: 'Gill Sans Light', 'Gill Sans MT Light', Lato, Helvetica, Arial, sans-serif;
     font-weight:300;
-    padding: 0 40px 40px 40px;
+    padding: 0px 40px 40px 40px;
     border-bottom:1px solid #ccc;
-    a {margin-left:5px;}
+    a {
+      display:block;
+      margin-left:5px;
+    }
   }
-  li:before {
+
+  #faq1::before{
     display: none; 
   }
+    
   li:last-child {border-bottom:0;}
   ol {
     margin-top:20px;
@@ -389,7 +399,7 @@ section.specification {
     ul.faq-nav > li{
       margin: 0 20px 0 20px;  
       padding: 0 20px 0 20px;  
-    } 
+    }
     div.side-nav.affix {position:relative}
   }
 }

--- a/faq.html
+++ b/faq.html
@@ -16,7 +16,7 @@ menu: FAQ
             <li><a href="#faq1">What is the Standard Health Record (SHR) Initiative?</a></li>
             <li><a href="#faq2">What is the Standard Health Record (SHR)?</a></li>
             <li><a href="#faq3">Is the SHR an open source project on GitHub?</a></li>
-            <li><a href="#faq4">Is the SHR technical approach different than what has been done in the past for Health Data Interoperability in the US?</a></li>
+            <li><a href="#faq4"><div>Is the SHR technical approach different than what has been done in the past for Health Data Interoperability in the US?</div></a></li>
             <li><a href="#faq5">What do we think will make SHR successful when past efforts have failed?</a></li>
             <li><a href="#faq6">Is anyone else standardizing health data or is the SHR project alone?</a></li>
             <li><a href="#faq7">When will a working SHR be available?</a></li>
@@ -27,100 +27,100 @@ menu: FAQ
         </div>
         <div class="col-sm-8">
           <ul class="faqs">
-          <li id="faq1">
-            <span class="faq-title title">What is the Standard Health Record (SHR) Initiative?</span>
-            <div class="faq-answer">
-              <p>The SHR Initiative is an open-source health data interoperability effort based at The MITRE Corporation located in Bedford, MA. The SHR Initiative aims to address the challenge of health data interoperability by focusing on the establishment of standards for the structure and content of health record information.</p>
-              <p>The SHR Initiative is recommending and prototyping health records that leverage existing medical record models and account for the data needs of patient identification and primary and emergency care providers. The SHR is also actively addressing the dynamic needs of patients and their caregivers over the life course by including a specification for many areas related to social determinants of health.</p>
-              <p>The SHR Initiative is patient-centric, while being highly attuned to the needs of care providers across a wide-spectrum of disciplines, and holds that patients must have access to their data in an understandable, portable, and transparent manner. As an open source model, the SHR actively promotes industry innovation in leveraging big-data at the patient and population level to increase patient engagement, support public health and research needs, and ensure providers have the right information, at the right time, for the right person.</p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq1">
+              <span class="faq-title title">What is the Standard Health Record (SHR) Initiative?</span>
+              <div class="faq-answer">
+                <p>The SHR Initiative is an open-source health data interoperability effort based at The MITRE Corporation located in Bedford, MA. The SHR Initiative aims to address the challenge of health data interoperability by focusing on the establishment of standards for the structure and content of health record information.</p>
+                <p>The SHR Initiative is recommending and prototyping health records that leverage existing medical record models and account for the data needs of patient identification and primary and emergency care providers. The SHR is also actively addressing the dynamic needs of patients and their caregivers over the life course by including a specification for many areas related to social determinants of health.</p>
+                <p>The SHR Initiative is patient-centric, while being highly attuned to the needs of care providers across a wide-spectrum of disciplines, and holds that patients must have access to their data in an understandable, portable, and transparent manner. As an open source model, the SHR actively promotes industry innovation in leveraging big-data at the patient and population level to increase patient engagement, support public health and research needs, and ensure providers have the right information, at the right time, for the right person.</p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq2">
-            <span class="faq-title title">What is the Standard Health Record (SHR)?</span>
-            <div class="faq-answer">
-              <p>The Standard Health Record (SHR) establishes a US national standard for the content of electronic health records. Health records conforming to the SHR specification contain all information critical to patient identification, emergency and primary care. Future extensions will support emerging treatment paradigms such as genomics, microbiomics, and precision medicine. Patients own the information in their SHRs and control who can access them and contribute information.</p>
-              <p>Widespread SHR implementation will result in interoperability across geographical locations and care settings. Health-related services including telecare, clinical decision support, and quality measurement are supported by SHR, improving healthcare access, quality, and uniformity. SHR provides the foundation for collection, communication, and aggregation of patient data, accelerating secondary uses in public health, disease surveillance, post-approval monitoring, and patient-centered outcomes research. Patients, clinicians, and the American public will realize major benefits from improved care coordination, reduction of medical errors, and decreased costs that accompany healthier lives. </p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq2">
+              <span class="faq-title title">What is the Standard Health Record (SHR)?</span>
+              <div class="faq-answer">
+                <p>The Standard Health Record (SHR) establishes a US national standard for the content of electronic health records. Health records conforming to the SHR specification contain all information critical to patient identification, emergency and primary care. Future extensions will support emerging treatment paradigms such as genomics, microbiomics, and precision medicine. Patients own the information in their SHRs and control who can access them and contribute information.</p>
+                <p>Widespread SHR implementation will result in interoperability across geographical locations and care settings. Health-related services including telecare, clinical decision support, and quality measurement are supported by SHR, improving healthcare access, quality, and uniformity. SHR provides the foundation for collection, communication, and aggregation of patient data, accelerating secondary uses in public health, disease surveillance, post-approval monitoring, and patient-centered outcomes research. Patients, clinicians, and the American public will realize major benefits from improved care coordination, reduction of medical errors, and decreased costs that accompany healthier lives. </p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq3">
-            <span class="faq-title title">Is the SHR an open source project on GitHub?</span>
-            <div class="faq-answer">
-              <p>Yes. The development of the SHR and all resources are open source since the very start of the effort. You can find the SHR on GitHub at <a href="https://github.com/standardhealth">https://github.com/standardhealth</a>. If you are interested in participating in the development of the SHR please email <a href="mailto:shr-project-list@lists.mitre.org">shr-project-list@lists.mitre.org</a> or enter an issue on the SHR GitHub page. </p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq3">
+              <span class="faq-title title">Is the SHR an open source project on GitHub?</span>
+              <div class="faq-answer">
+                <p>Yes. The development of the SHR and all resources are open source since the very start of the effort. You can find the SHR on GitHub at <a href="https://github.com/standardhealth">https://github.com/standardhealth</a>. If you are interested in participating in the development of the SHR please email <a href="mailto:shr-project-list@lists.mitre.org">shr-project-list@lists.mitre.org</a> or enter an issue on the SHR GitHub page. </p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq4">
-            <span class="faq-title title">Is the SHR technical approach different than what has been done in the past for Health Data Interoperability in the US?</span>
-            <div class="faq-answer">
-              <p>Yes. To explain why the SHR approach is different requires some background.</p>
-              <p>Healthcare in the US was a paper-based system long after most other industries had converted to modern, digital information technology. Known as Electronic Medical Record (EMR) or Electronic Health Record (EHR) systems, these systems have only become the norm within the last 10 years.</p>
-              <p>Between 2001 and 2015, the adoption of EMR/EHR systems went from 9% to 96% in the inpatient (hospital) setting and from 18% to 83% in the outpatient (non-hospital) setting. This change was due to aggressive government incentive programs for health information technology (health IT) adoption (e.g., Meaningful Use). Where other industries shifted to electronic records and digital data gradually as part of business strategy, healthcare made the shift very rapidly, locking in many inconsistencies in data capture and data representation.</p>
-              <p>Today there are 1,482 different EMR/EHR health IT system products certified as part of HHS Meaningful Use. Most of those health IT products are themselves highly configurable to facilitate conditions in divergent clinical settings. This explains why, even after the nearly universal adoption of health IT technology has occurred, the primary mechanism of communication between clinicians remains the fax machine which is reliant on manual human interpretation of text on paper.</p>
-              <p>Twenty years ago, the healthcare industry turned towards interoperability standards to improve healthcare information exchange. However, the very lack of data consistency was not acknowledged and has led to exchange standards that are purposefully left extremely flexible, allowing enough freedom to model the information in virtually any EHR system. Even new standards like HL7’s FAST Healthcare Interoperability Resources (FHIR) have made a deliberate decision to remain very flexible and ambiguous on data specificity. While FHIR provides a far more solid foundation then previous healthcare exchange standards, problems of inconsistent implementation and low levels of semantic interoperability remain.</p>
-              <p>In our view, the real problem lies much deeper than the flexibility of information exchange standards. In addition to capturing too much information as free text, the fundamental problem is that today’s health IT systems contain semantically incompatible information. Because of the great variety of the data models of EMR/EHR systems, transferring information from one health IT system to another frequently results in distorted or lost information, blocking of critical details, or introduction of erroneous information. This is unacceptable in healthcare. Under these circumstances, the solution must lie in aligning the information at the sources.</p>
-              <p><strong>The approach of the Standard Health Record (SHR) is to standardize the health record and health data itself, rather than focusing on exchange standards. When the health record and data is standardized, exchange and aggregation of patient information will become trivial (as in every other industry that has gone digital).</p>
-              <p> <a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq4">
+              <span class="faq-title title">Is the SHR technical approach different than what has been done in the past for Health Data Interoperability in the US?</span>
+              <div class="faq-answer">
+                <p>Yes. To explain why the SHR approach is different requires some background.</p>
+                <p>Healthcare in the US was a paper-based system long after most other industries had converted to modern, digital information technology. Known as Electronic Medical Record (EMR) or Electronic Health Record (EHR) systems, these systems have only become the norm within the last 10 years.</p>
+                <p>Between 2001 and 2015, the adoption of EMR/EHR systems went from 9% to 96% in the inpatient (hospital) setting and from 18% to 83% in the outpatient (non-hospital) setting. This change was due to aggressive government incentive programs for health information technology (health IT) adoption (e.g., Meaningful Use). Where other industries shifted to electronic records and digital data gradually as part of business strategy, healthcare made the shift very rapidly, locking in many inconsistencies in data capture and data representation.</p>
+                <p>Today there are 1,482 different EMR/EHR health IT system products certified as part of HHS Meaningful Use. Most of those health IT products are themselves highly configurable to facilitate conditions in divergent clinical settings. This explains why, even after the nearly universal adoption of health IT technology has occurred, the primary mechanism of communication between clinicians remains the fax machine which is reliant on manual human interpretation of text on paper.</p>
+                <p>Twenty years ago, the healthcare industry turned towards interoperability standards to improve healthcare information exchange. However, the very lack of data consistency was not acknowledged and has led to exchange standards that are purposefully left extremely flexible, allowing enough freedom to model the information in virtually any EHR system. Even new standards like HL7’s FAST Healthcare Interoperability Resources (FHIR) have made a deliberate decision to remain very flexible and ambiguous on data specificity. While FHIR provides a far more solid foundation then previous healthcare exchange standards, problems of inconsistent implementation and low levels of semantic interoperability remain.</p>
+                <p>In our view, the real problem lies much deeper than the flexibility of information exchange standards. In addition to capturing too much information as free text, the fundamental problem is that today’s health IT systems contain semantically incompatible information. Because of the great variety of the data models of EMR/EHR systems, transferring information from one health IT system to another frequently results in distorted or lost information, blocking of critical details, or introduction of erroneous information. This is unacceptable in healthcare. Under these circumstances, the solution must lie in aligning the information at the sources.</p>
+                <p><strong>The approach of the Standard Health Record (SHR) is to standardize the health record and health data itself, rather than focusing on exchange standards. When the health record and data is standardized, exchange and aggregation of patient information will become trivial (as in every other industry that has gone digital).</p>
+                <p> <a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq5">
-            <span class="faq-title title">What do we think will make SHR successful when past efforts have failed?</span>
-            <div class="faq-answer">
-              <p>MITRE and the SHR open source community recognize that achieving consistency in healthcare data will be a difficult problem to solve. There will be resistance to change and building consensus will be a challenge. MITRE and the SHR open source community’s influence on health policy and health standards will be as important as the SHR technical innovation. This is why the SHR effort invests heavily in engagement with healthcare thought leaders and health and healthcare alliances. The SHR community is connecting with medical associations, standards organizations, and vendor consortia such as Commonwell Health Alliance, the Argonauts, the National Association for Trusted Exchange (NATE), the Carequality Collaborative, The Sequoia Project, and the Healthcare Services Platform Consortium.</p>
-              <p>The SHR community will also build on existing standards and borrow from similar initiatives outside of the US. For example, the ONC Common Clinical Data Set (CCDS), which mandates several types of information be exchanged during transitions of care, is a natural building block for the SHR. England has published standards for the clinical structure and content of patient records. Both England and US standards fall short of defining the structured data necessary for a computable SHR, so we are addressing that today. Other existing data models, such as the Federal Health Information Model (FHIM), the OMOP Common Data Model, the Observational Health Data Sciences and Informatics (OHDSI) &ldquo;Common Data Model&rdquo;, and FHIR resources provide important and valuable inputs. But none of these models, nor any similar healthcare model that we are aware of, fully defines the content of a useful, complete standard health record.</p>
-              <p>With FHIR establishing a solid foundation for basic exchange, the time is right to try and solve this critical problem. MITRE and the SHR open source community can provide a target and start working towards nationwide adoption of the SHR.</p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq5">
+              <span class="faq-title title">What do we think will make SHR successful when past efforts have failed?</span>
+              <div class="faq-answer">
+                <p>MITRE and the SHR open source community recognize that achieving consistency in healthcare data will be a difficult problem to solve. There will be resistance to change and building consensus will be a challenge. MITRE and the SHR open source community’s influence on health policy and health standards will be as important as the SHR technical innovation. This is why the SHR effort invests heavily in engagement with healthcare thought leaders and health and healthcare alliances. The SHR community is connecting with medical associations, standards organizations, and vendor consortia such as Commonwell Health Alliance, the Argonauts, the National Association for Trusted Exchange (NATE), the Carequality Collaborative, The Sequoia Project, and the Healthcare Services Platform Consortium.</p>
+                <p>The SHR community will also build on existing standards and borrow from similar initiatives outside of the US. For example, the ONC Common Clinical Data Set (CCDS), which mandates several types of information be exchanged during transitions of care, is a natural building block for the SHR. England has published standards for the clinical structure and content of patient records. Both England and US standards fall short of defining the structured data necessary for a computable SHR, so we are addressing that today. Other existing data models, such as the Federal Health Information Model (FHIM), the OMOP Common Data Model, the Observational Health Data Sciences and Informatics (OHDSI) &ldquo;Common Data Model&rdquo;, and FHIR resources provide important and valuable inputs. But none of these models, nor any similar healthcare model that we are aware of, fully defines the content of a useful, complete standard health record.</p>
+                <p>With FHIR establishing a solid foundation for basic exchange, the time is right to try and solve this critical problem. MITRE and the SHR open source community can provide a target and start working towards nationwide adoption of the SHR.</p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq6">
-            <span class="faq-title title">Is anyone else standardizing health data or is the SHR project alone?</span>
-            <div class="faq-answer">
-              <p>This is not the first effort to standardize health data. Internationally, many of the top healthcare systems in the world have defined or are in the process of developing a standard health record.  For example, a standard health record (the Summary Care Record) has been successfully adopted in England, and it has provided very positive results. Many developed countries have some form of a standard health record. The US is behind in this respect. </p>
-              <p>While international efforts will help to inform the Standard Health Record, there are many areas where the SHR project can leapfrog those older developments. For instance, many of the internationally defined standard health records focus on standardizing narrative data sections alone and do not address fine-grained structured data. We will use FHIR to access and exchange the contents of the SHR down to individual data elements (current patient core temperature in degrees F). There are other groups whose work can be leveraged to accelerate the SHR, including the Clinical Information Modeling Initiative (CIMI). The CIMI project is developing a detailed specification for exchanging laboratory health information that may also leverage the SHR.</p>
-              <p>The SHR team is also working to convene a Blue Ribbon Panel of experts to leverage the broader healthcare community in the development of the SHR. The Blue Ribbon Panel will oversee, validate, and advocate for the SHR. Panel members will represent a diverse yet connected set of individuals across multiple institutional settings and content domains.  The SHR initiative aims to gain from the Blue Ribbon Panel:</p>
-              <ol>
-                <li>Actionable ideas based on broad, yet content rich discussion</li>
-                <li>Guidance on next steps for advancing the SHR work</li>
-                <li>The identification of, and skilled support in, overcoming potential barriers</li>
-                <li>Strategic support in building external relationships critical for the successful nationwide adoption of the SHR.</li>
-              </ol>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq6">
+              <span class="faq-title title">Is anyone else standardizing health data or is the SHR project alone?</span>
+              <div class="faq-answer">
+                <p>This is not the first effort to standardize health data. Internationally, many of the top healthcare systems in the world have defined or are in the process of developing a standard health record.  For example, a standard health record (the Summary Care Record) has been successfully adopted in England, and it has provided very positive results. Many developed countries have some form of a standard health record. The US is behind in this respect. </p>
+                <p>While international efforts will help to inform the Standard Health Record, there are many areas where the SHR project can leapfrog those older developments. For instance, many of the internationally defined standard health records focus on standardizing narrative data sections alone and do not address fine-grained structured data. We will use FHIR to access and exchange the contents of the SHR down to individual data elements (current patient core temperature in degrees F). There are other groups whose work can be leveraged to accelerate the SHR, including the Clinical Information Modeling Initiative (CIMI). The CIMI project is developing a detailed specification for exchanging laboratory health information that may also leverage the SHR.</p>
+                <p>The SHR team is also working to convene a Blue Ribbon Panel of experts to leverage the broader healthcare community in the development of the SHR. The Blue Ribbon Panel will oversee, validate, and advocate for the SHR. Panel members will represent a diverse yet connected set of individuals across multiple institutional settings and content domains.  The SHR initiative aims to gain from the Blue Ribbon Panel:</p>
+                <ol>
+                  <li>Actionable ideas based on broad, yet content rich discussion</li>
+                  <li>Guidance on next steps for advancing the SHR work</li>
+                  <li>The identification of, and skilled support in, overcoming potential barriers</li>
+                  <li>Strategic support in building external relationships critical for the successful nationwide adoption of the SHR.</li>
+                </ol>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq7">
-            <span class="faq-title title">When will a working SHR be available?</span>
-            <div class="faq-answer">
-              <p>The development and approval of the first SHR specification is estimated to take two years (through 2018). The time to 50% adoption of that specification will be five years (2023), with 90% adoption in 8 years (2026).</p> 
-              <p> <a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq7">
+              <span class="faq-title title">When will a working SHR be available?</span>
+              <div class="faq-answer">
+                <p>The development and approval of the first SHR specification is estimated to take two years (through 2018). The time to 50% adoption of that specification will be five years (2023), with 90% adoption in 8 years (2026).</p> 
+                <p> <a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq8">
-            <span class="faq-title title">Will SHR address only &ldquo;traditional electronic health records&rdquo; or will SHR be much broader in scope and include non-hospital health data?</span>
-            <div class="faq-answer">
-              <p>The plan is to initially focus on electronic health record data for patient identification, emergency care, and primary care. After those initial domains have been developed, the Standard Health Record will be expanded to cover other domains such as precision care, inpatient care, genomics, social determinants of health, and patient generated data. Early SHR work will establish a repeatable process to &ldquo;standardize health data&rdquo; that will be extended to new use cases as an evolutionary strategy to standardize the majority of modern health and healthcare data.</p>
-              <p>The SHR community will look to the Blue Ribbon Panel, and the national healthcare community at large, to help identify the key health data domains to add next.  However, we want to begin with a manageable yet impactful set of initial domains to prove the SHR concept and define the technical representation. We will continue to work through the consensus process, better understand and develop solutions to policy, privacy, patient consent, and security issues around the SHR for the next 2 to 5 years. </p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>
+            <li id="faq8">
+              <span class="faq-title title">Will SHR address only &ldquo;traditional electronic health records&rdquo; or will SHR be much broader in scope and include non-hospital health data?</span>
+              <div class="faq-answer">
+                <p>The plan is to initially focus on electronic health record data for patient identification, emergency care, and primary care. After those initial domains have been developed, the Standard Health Record will be expanded to cover other domains such as precision care, inpatient care, genomics, social determinants of health, and patient generated data. Early SHR work will establish a repeatable process to &ldquo;standardize health data&rdquo; that will be extended to new use cases as an evolutionary strategy to standardize the majority of modern health and healthcare data.</p>
+                <p>The SHR community will look to the Blue Ribbon Panel, and the national healthcare community at large, to help identify the key health data domains to add next.  However, we want to begin with a manageable yet impactful set of initial domains to prove the SHR concept and define the technical representation. We will continue to work through the consensus process, better understand and develop solutions to policy, privacy, patient consent, and security issues around the SHR for the next 2 to 5 years. </p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>
 
-          <li id="faq9">
-            <span class="faq-title title">How is SHR different from FHIR?</span>
-            <div class="faq-answer">
-              <p>FHIR is an exchange standard, not a content specification. FHIR defines high level classes of things, such as &ldquo;person,&rdquo; &ldquo;immunization,&rdquo; and &ldquo;observation&rdquo;, that might be exchanged between healthcare systems. It provides no information about what particular persons, immunizations, or observations might be important. In contrast, the SHR lists specific things that should be part of every health record, for example, specific persons (e.g., an emergency contact), specific immunizations (e.g., the date of the last tetanus shot), and specific observations (e.g., the patients fasting glucose). </p>
-              <p>The SHR Initiative is recommending and prototyping health records that leverage existing medical record models and account for the data needs of primary and emergency care providers. The SHR is also actively addressing the dynamic needs of patients and their caregivers over the life course by including a recommended structure and content for documenting many variables related to social determinants of health.</p>
-              <p>The SHR Initiative is patient-centric, while being highly attuned to the needs of care providers across a wide-spectrum of disciplines, and believes that patients must have access to their data in an understandable, portable, and transparent manner. As an open source model, the SHR actively promotes industry innovation in leveraging big-data at the patient and population level to increase patient engagement, support public health and research needs, and ensure providers have the right information, at the right time, for the right person. </p>
-              <p><a href="#top" class='back-to-top'>Back to top</a></p>
-            </div>
-          </li>   
-         </ul>
+            <li id="faq9">
+              <span class="faq-title title">How is SHR different from FHIR?</span>
+              <div class="faq-answer">
+                <p>FHIR is an exchange standard, not a content specification. FHIR defines high level classes of things, such as &ldquo;person,&rdquo; &ldquo;immunization,&rdquo; and &ldquo;observation&rdquo;, that might be exchanged between healthcare systems. It provides no information about what particular persons, immunizations, or observations might be important. In contrast, the SHR lists specific things that should be part of every health record, for example, specific persons (e.g., an emergency contact), specific immunizations (e.g., the date of the last tetanus shot), and specific observations (e.g., the patients fasting glucose). </p>
+                <p>The SHR Initiative is recommending and prototyping health records that leverage existing medical record models and account for the data needs of primary and emergency care providers. The SHR is also actively addressing the dynamic needs of patients and their caregivers over the life course by including a recommended structure and content for documenting many variables related to social determinants of health.</p>
+                <p>The SHR Initiative is patient-centric, while being highly attuned to the needs of care providers across a wide-spectrum of disciplines, and believes that patients must have access to their data in an understandable, portable, and transparent manner. As an open source model, the SHR actively promotes industry innovation in leveraging big-data at the patient and population level to increase patient engagement, support public health and research needs, and ensure providers have the right information, at the right time, for the right person. </p>
+                <p><a href="#top" class='back-to-top'>Back to top</a></p>
+              </div>
+            </li>   
+          </ul>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Currently are using :before pseudo elem to create padding, but this padding will sit over the links on the FAQ in a mobile view, rendering the links unusable. This implementation disables the :before element on faq1 as an improvement on the older version, but N.B. that this is still an issue.
