### PR TITLE
Changes for 11/28/16 to 12/1/16

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+standardhealthrecord.org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-standardhealthrecord.org

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,7 +28,7 @@
                 <a href="/faq.html">FAQ</a>
               </li>
               <li class="scroll">
-                <a href="/#collaboration">COLLABORATE</a>
+                <a href="/#contact">CONTACT</a>
               </li>
             </ul>
           </div>
@@ -51,7 +51,7 @@
     </div>
     <div class="row" role="copyright">
       <div class="col-sm-6 col-sm-offset-6">
-        <p class="copyright">Copyright © 2016 The MITRE Corporation | Approved for Public Release; Distribution Unlimited. Case Number 16-1988 </p>
+        <p class="copyright">Copyright © 2016 The MITRE Corporation | Approved for Public Release; Distribution Unlimited. Case Number 16&#8209;1988 </p>
       </div> 
     </div>
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -35,7 +35,7 @@
             <a href="/faq.html">FAQ</a>
           </li>
           <li class="scroll">
-            <a href="/#collaboration">CONTACT </a>
+            <a href="/#contact">CONTACT</a>
           </li>
         </ul>
       </div>

--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -382,6 +382,12 @@ section#about:before {
            text-align: left;
            font-size: $base-font-size;
         }
+        h2 > a { 
+            padding: 0;
+        }
+    }
+    h2, a {
+        padding: 0 10px 0 10px;
     }
     h2 > a  { 
         font-size: $md-font-size;
@@ -868,13 +874,29 @@ footer {
             }
         }
     }
-    @media (max-width : 375px) { 
-        #home {
-            .btn.btn-raised.btn-default { 
-                margin: 20px 10px 0 10px;
-                color: white;
-                background-color: $clr-primary;
+}
+
+@media (max-width : 375px) { 
+    #home {
+        .btn.btn-raised.btn-default { 
+            margin: 20px 10px 0 10px;
+            color: white;
+            background-color: $clr-primary;
+        }
+    }
+    #spec-viewer {
+        .section-heading { 
+            padding-bottom: 10px;
+            h2, a{ 
+               text-align: left;
+               font-size: $base-font-size;
             }
+        }
+        h2, a {
+            padding: 0 10px 0 10px;
+        }
+        h2 > a  { 
+            font-size: $sm-font-size;
         }
     }
 }

--- a/_scss/_layout.scss
+++ b/_scss/_layout.scss
@@ -408,9 +408,9 @@ section#about:before {
 
 
 /*****************/
-/* Collaboration */
+/* contact       */
 /*****************/
-#collaboration {    
+#contact {    
     p, h6 {
         margin: 20px 0 10px 0; 
     }
@@ -737,7 +737,7 @@ footer {
             }
         }
     }
-    #collaboration {
+    #contact {
         .section-content {
             padding: 0 40px 10px 40px;
         }
@@ -858,7 +858,7 @@ footer {
             margin: 0 20px; 
         }
     }
-    #collaboration {
+    #contact {
         .section-content {
             padding: 0 30px 10px 30px;
         }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ title: home
         <div class="col-sm-12">
           <h1>The Standard Health Record Collaborative</h1>
           <h2>One human, </h2> 
-          <h2>One health record.</h2>
+          <h2>One health record</h2>
           <div class="row">
             <div class="col-xs-12">
               <div class="scroll">
@@ -107,7 +107,7 @@ title: home
   </div>
 </section>
 
-<section id="collaboration">
+<section id="contact">
   <div class="container"> 
     <div class="row"> 
       <div class="section-heading">

--- a/index.html
+++ b/index.html
@@ -9,11 +9,12 @@ title: home
       <div class="row">
         <div class="col-sm-12">
           <h1>The Standard Health Record Collaborative</h1>
-          <h2>One human, one health record</h2>
+          <h2>One human, </h2> 
+          <h2>One health record.</h2>
           <div class="row">
             <div class="col-xs-12">
               <div class="scroll">
-                <a href="/#about" class="btn btn-raised btn-lg btn-default">Learn More</a>
+<!--                 <a href="/#about" class="btn btn-raised btn-lg btn-default">Learn More</a> -->
                 <a href="/shr/" class="btn btn-raised btn-lg btn-default">View the Spec</a>
               </div>
             </div>
@@ -110,7 +111,7 @@ title: home
   <div class="container"> 
     <div class="row"> 
       <div class="section-heading">
-        <h1 class="text-center">GET INVOLVED</h1>
+        <h1 class="text-center">CONTACT US</h1>
         <h2 class="text-center">Help Improve the SHR</h2>
       </div>
     </div> 

--- a/js/main.js
+++ b/js/main.js
@@ -4,11 +4,11 @@ $('#site-menu a').on('touchend', function(e) {
     var link = el.attr('href');
     window.location = link;
 });
+
 // Scroll to nav link if possible
 //
 $('.scroll a').on('click',function() {      
     $('html, body').animate({scrollTop: $(this.hash).offset().top - 50}, 1000);
-        return false;
 });
 
 $(window).scroll(function(event) {

--- a/js/main.js
+++ b/js/main.js
@@ -7,9 +7,9 @@ $('#site-menu a').on('touchend', function(e) {
 
 // Scroll to nav link if possible
 //
-$('.scroll a').on('click',function() {      
-    $('html, body').animate({scrollTop: $(this.hash).offset().top - 50}, 1000);
-});
+// $('.scroll a').on('click',function() {      
+//     $('html, body').animate({scrollTop: $(this.hash).offset().top - 50}, 1000);
+// });
 
 $(window).scroll(function(event) {
         updateActive();


### PR DESCRIPTION
-	Home Section: 
o	Added a line break between the tagline “One human, one health record”.
o	Removed the ‘Learn More’ button
o	Sent email to MITRE personnel asking for a new landing page photo, one that doesn’t require Creative Commons citations. (Should be up by EOB). 
-	Contact Section: 
o	Changed the ‘collaboration’ section to be the ‘contact’ section. 
o	Structured the footer so the case number doesn’t line-break on the hyphen for small screens.
-	Spec Viewer: 
o	Added padding on the Spec viewer page so the spec elements had some space between them and the left hand side of the screen. 
