### PR TITLE
Adds redirect pages

### DIFF
--- a/shr/adverse/cs/AttributionCategoryCS/index.html
+++ b/shr/adverse/cs/AttributionCategoryCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/adverse/cs/#AttributionCategoryCS'" />    
+</head>

--- a/shr/adverse/vs/AdverseEventGradeVS/index.html
+++ b/shr/adverse/vs/AdverseEventGradeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/adverse/vs/#AdverseEventGradeVS'" />    
+</head>

--- a/shr/adverse/vs/AttributionCategoryVS/index.html
+++ b/shr/adverse/vs/AttributionCategoryVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/adverse/vs/#AttributionCategoryVS'" />    
+</head>

--- a/shr/adverse/vs/MedDRAVS/index.html
+++ b/shr/adverse/vs/MedDRAVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/adverse/vs/#MedDRAVS'" />    
+</head>

--- a/shr/adverse/vs/ToxicReactionVS/index.html
+++ b/shr/adverse/vs/ToxicReactionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/adverse/vs/#ToxicReactionVS'" />    
+</head>

--- a/shr/allergy/vs/AllergenIrritantVS/index.html
+++ b/shr/allergy/vs/AllergenIrritantVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/allergy/vs/#AllergenIrritantVS'" />    
+</head>

--- a/shr/allergy/vs/AllergyVerificationStatusVS/index.html
+++ b/shr/allergy/vs/AllergyVerificationStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/allergy/vs/#AllergyVerificationStatusVS'" />    
+</head>

--- a/shr/allergy/vs/FoodSubstanceVS/index.html
+++ b/shr/allergy/vs/FoodSubstanceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/allergy/vs/#FoodSubstanceVS'" />    
+</head>

--- a/shr/allergy/vs/ManifestationVS/index.html
+++ b/shr/allergy/vs/ManifestationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/allergy/vs/#ManifestationVS'" />    
+</head>

--- a/shr/allergy/vs/NoKnownAllergyVS/index.html
+++ b/shr/allergy/vs/NoKnownAllergyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/allergy/vs/#NoKnownAllergyVS'" />    
+</head>

--- a/shr/base/cs/ProposedStatusCS/index.html
+++ b/shr/base/cs/ProposedStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/base/cs/#ProposedStatusCS'" />    
+</head>

--- a/shr/base/vs/ProposedStatusVS/index.html
+++ b/shr/base/vs/ProposedStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/base/vs/#ProposedStatusVS'" />    
+</head>

--- a/shr/behavior/cs/AlcoholUseScreeningToolCS/index.html
+++ b/shr/behavior/cs/AlcoholUseScreeningToolCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#AlcoholUseScreeningToolCS'" />    
+</head>

--- a/shr/behavior/cs/DietFollowedCS/index.html
+++ b/shr/behavior/cs/DietFollowedCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#DietFollowedCS'" />    
+</head>

--- a/shr/behavior/cs/DietNutritionConcernCS/index.html
+++ b/shr/behavior/cs/DietNutritionConcernCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#DietNutritionConcernCS'" />    
+</head>

--- a/shr/behavior/cs/PhysicalActivityLimitationCS/index.html
+++ b/shr/behavior/cs/PhysicalActivityLimitationCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#PhysicalActivityLimitationCS'" />    
+</head>

--- a/shr/behavior/cs/ReligiousPracticeStatusCS/index.html
+++ b/shr/behavior/cs/ReligiousPracticeStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#ReligiousPracticeStatusCS'" />    
+</head>

--- a/shr/behavior/cs/ReligiousRestrictionCS/index.html
+++ b/shr/behavior/cs/ReligiousRestrictionCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#ReligiousRestrictionCS'" />    
+</head>

--- a/shr/behavior/cs/SleepQualityCauseCS/index.html
+++ b/shr/behavior/cs/SleepQualityCauseCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#SleepQualityCauseCS'" />    
+</head>

--- a/shr/behavior/cs/SubstanceAbuseTreatmentTypeCS/index.html
+++ b/shr/behavior/cs/SubstanceAbuseTreatmentTypeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/cs/#SubstanceAbuseTreatmentTypeCS'" />    
+</head>

--- a/shr/behavior/vs/AlcoholUseScreeningToolVS/index.html
+++ b/shr/behavior/vs/AlcoholUseScreeningToolVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#AlcoholUseScreeningToolVS'" />    
+</head>

--- a/shr/behavior/vs/DietFollowedVS/index.html
+++ b/shr/behavior/vs/DietFollowedVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#DietFollowedVS'" />    
+</head>

--- a/shr/behavior/vs/DietNutritionConcernVS/index.html
+++ b/shr/behavior/vs/DietNutritionConcernVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#DietNutritionConcernVS'" />    
+</head>

--- a/shr/behavior/vs/PhysicalActivityLimitationVS/index.html
+++ b/shr/behavior/vs/PhysicalActivityLimitationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#PhysicalActivityLimitationVS'" />    
+</head>

--- a/shr/behavior/vs/ReligiousPracticeStatusVS/index.html
+++ b/shr/behavior/vs/ReligiousPracticeStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#ReligiousPracticeStatusVS'" />    
+</head>

--- a/shr/behavior/vs/ReligiousRestrictionVS/index.html
+++ b/shr/behavior/vs/ReligiousRestrictionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#ReligiousRestrictionVS'" />    
+</head>

--- a/shr/behavior/vs/SleepQualityCauseVS/index.html
+++ b/shr/behavior/vs/SleepQualityCauseVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#SleepQualityCauseVS'" />    
+</head>

--- a/shr/behavior/vs/SubstanceAbuseTreatmentTypeVS/index.html
+++ b/shr/behavior/vs/SubstanceAbuseTreatmentTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#SubstanceAbuseTreatmentTypeVS'" />    
+</head>

--- a/shr/behavior/vs/SubstanceOfAbuseVS/index.html
+++ b/shr/behavior/vs/SubstanceOfAbuseVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/behavior/vs/#SubstanceOfAbuseVS'" />    
+</head>

--- a/shr/condition/cs/ConditionCategoryCS/index.html
+++ b/shr/condition/cs/ConditionCategoryCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/cs/#ConditionCategoryCS'" />    
+</head>

--- a/shr/condition/vs/ConditionCategoryVS/index.html
+++ b/shr/condition/vs/ConditionCategoryVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/vs/#ConditionCategoryVS'" />    
+</head>

--- a/shr/condition/vs/ConditionVS/index.html
+++ b/shr/condition/vs/ConditionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/vs/#ConditionVS'" />    
+</head>

--- a/shr/condition/vs/DSMVS/index.html
+++ b/shr/condition/vs/DSMVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/vs/#DSMVS'" />    
+</head>

--- a/shr/condition/vs/ProgressionEvidenceTypeVS/index.html
+++ b/shr/condition/vs/ProgressionEvidenceTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/vs/#ProgressionEvidenceTypeVS'" />    
+</head>

--- a/shr/condition/vs/ProgressionVS/index.html
+++ b/shr/condition/vs/ProgressionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/condition/vs/#ProgressionVS'" />    
+</head>

--- a/shr/core/cs/CodingQualifierCS/index.html
+++ b/shr/core/cs/CodingQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#CodingQualifierCS'" />    
+</head>

--- a/shr/core/cs/PerformanceGradingScaleCS/index.html
+++ b/shr/core/cs/PerformanceGradingScaleCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#PerformanceGradingScaleCS'" />    
+</head>

--- a/shr/core/cs/QualitativeDateTimeCS/index.html
+++ b/shr/core/cs/QualitativeDateTimeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#QualitativeDateTimeCS'" />    
+</head>

--- a/shr/core/cs/QualitativeFrequencyCS/index.html
+++ b/shr/core/cs/QualitativeFrequencyCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#QualitativeFrequencyCS'" />    
+</head>

--- a/shr/core/cs/QualitativeLikelihoodCS/index.html
+++ b/shr/core/cs/QualitativeLikelihoodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#QualitativeLikelihoodCS'" />    
+</head>

--- a/shr/core/cs/QualitativeValueScaleCS/index.html
+++ b/shr/core/cs/QualitativeValueScaleCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#QualitativeValueScaleCS'" />    
+</head>

--- a/shr/core/cs/SemiquantitativeDurationCS/index.html
+++ b/shr/core/cs/SemiquantitativeDurationCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeDurationCS'" />    
+</head>

--- a/shr/core/cs/SemiquantitativeFrequencyCS/index.html
+++ b/shr/core/cs/SemiquantitativeFrequencyCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#SemiquantitativeFrequencyCS'" />    
+</head>

--- a/shr/core/cs/SettingCS/index.html
+++ b/shr/core/cs/SettingCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#SettingCS'" />    
+</head>

--- a/shr/core/cs/ThreePriorityCS/index.html
+++ b/shr/core/cs/ThreePriorityCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#ThreePriorityCS'" />    
+</head>

--- a/shr/core/cs/YesNoCS/index.html
+++ b/shr/core/cs/YesNoCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#YesNoCS'" />    
+</head>

--- a/shr/core/cs/YesNoUnknownCS/index.html
+++ b/shr/core/cs/YesNoUnknownCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/cs/#YesNoUnknownCS'" />    
+</head>

--- a/shr/core/vs/BodyPositionVS/index.html
+++ b/shr/core/vs/BodyPositionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#BodyPositionVS'" />    
+</head>

--- a/shr/core/vs/BodySiteVS/index.html
+++ b/shr/core/vs/BodySiteVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#BodySiteVS'" />    
+</head>

--- a/shr/core/vs/ClinicalFindingAbsentVS/index.html
+++ b/shr/core/vs/ClinicalFindingAbsentVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#ClinicalFindingAbsentVS'" />    
+</head>

--- a/shr/core/vs/ClockDirectionVS/index.html
+++ b/shr/core/vs/ClockDirectionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#ClockDirectionVS'" />    
+</head>

--- a/shr/core/vs/CodingQualifierVS/index.html
+++ b/shr/core/vs/CodingQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#CodingQualifierVS'" />    
+</head>

--- a/shr/core/vs/CurrencyVS/index.html
+++ b/shr/core/vs/CurrencyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#CurrencyVS'" />    
+</head>

--- a/shr/core/vs/DirectionalityVS/index.html
+++ b/shr/core/vs/DirectionalityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#DirectionalityVS'" />    
+</head>

--- a/shr/core/vs/DiseaseFindingVS/index.html
+++ b/shr/core/vs/DiseaseFindingVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#DiseaseFindingVS'" />    
+</head>

--- a/shr/core/vs/LateralityVS/index.html
+++ b/shr/core/vs/LateralityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#LateralityVS'" />    
+</head>

--- a/shr/core/vs/LowerBoundTypeVS/index.html
+++ b/shr/core/vs/LowerBoundTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#LowerBoundTypeVS'" />    
+</head>

--- a/shr/core/vs/PerformanceGradingScaleVS/index.html
+++ b/shr/core/vs/PerformanceGradingScaleVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#PerformanceGradingScaleVS'" />    
+</head>

--- a/shr/core/vs/PortionTotalityVS/index.html
+++ b/shr/core/vs/PortionTotalityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#PortionTotalityVS'" />    
+</head>

--- a/shr/core/vs/QualitativeDateTimeVS/index.html
+++ b/shr/core/vs/QualitativeDateTimeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#QualitativeDateTimeVS'" />    
+</head>

--- a/shr/core/vs/QualitativeFrequencyVS/index.html
+++ b/shr/core/vs/QualitativeFrequencyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#QualitativeFrequencyVS'" />    
+</head>

--- a/shr/core/vs/QualitativeLikelihoodVS/index.html
+++ b/shr/core/vs/QualitativeLikelihoodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#QualitativeLikelihoodVS'" />    
+</head>

--- a/shr/core/vs/QualitativeValueScaleVS/index.html
+++ b/shr/core/vs/QualitativeValueScaleVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#QualitativeValueScaleVS'" />    
+</head>

--- a/shr/core/vs/QuestionCodeVS/index.html
+++ b/shr/core/vs/QuestionCodeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#QuestionCodeVS'" />    
+</head>

--- a/shr/core/vs/SemiquantitativeDurationVS/index.html
+++ b/shr/core/vs/SemiquantitativeDurationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#SemiquantitativeDurationVS'" />    
+</head>

--- a/shr/core/vs/SemiquantitativeFrequencyVS/index.html
+++ b/shr/core/vs/SemiquantitativeFrequencyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#SemiquantitativeFrequencyVS'" />    
+</head>

--- a/shr/core/vs/SettingVS/index.html
+++ b/shr/core/vs/SettingVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#SettingVS'" />    
+</head>

--- a/shr/core/vs/StatisticTypeVS/index.html
+++ b/shr/core/vs/StatisticTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#StatisticTypeVS'" />    
+</head>

--- a/shr/core/vs/ThreePriorityVS/index.html
+++ b/shr/core/vs/ThreePriorityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#ThreePriorityVS'" />    
+</head>

--- a/shr/core/vs/TimeUnitOfMeasureVS/index.html
+++ b/shr/core/vs/TimeUnitOfMeasureVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#TimeUnitOfMeasureVS'" />    
+</head>

--- a/shr/core/vs/UnitsOfLengthVS/index.html
+++ b/shr/core/vs/UnitsOfLengthVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#UnitsOfLengthVS'" />    
+</head>

--- a/shr/core/vs/UpperBoundTypeVS/index.html
+++ b/shr/core/vs/UpperBoundTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#UpperBoundTypeVS'" />    
+</head>

--- a/shr/core/vs/YesNoUnknownVS/index.html
+++ b/shr/core/vs/YesNoUnknownVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#YesNoUnknownVS'" />    
+</head>

--- a/shr/core/vs/YesNoVS/index.html
+++ b/shr/core/vs/YesNoVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/core/vs/#YesNoVS'" />    
+</head>

--- a/shr/device/cs/RespiratoryAssistDeviceCS/index.html
+++ b/shr/device/cs/RespiratoryAssistDeviceCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/device/cs/#RespiratoryAssistDeviceCS'" />    
+</head>

--- a/shr/device/cs/RespiratoryRateSettingCS/index.html
+++ b/shr/device/cs/RespiratoryRateSettingCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/device/cs/#RespiratoryRateSettingCS'" />    
+</head>

--- a/shr/device/vs/DeviceVS/index.html
+++ b/shr/device/vs/DeviceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/device/vs/#DeviceVS'" />    
+</head>

--- a/shr/device/vs/RespiratoryAssistDeviceVS/index.html
+++ b/shr/device/vs/RespiratoryAssistDeviceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/device/vs/#RespiratoryAssistDeviceVS'" />    
+</head>

--- a/shr/device/vs/RespiratoryRateSettingVS/index.html
+++ b/shr/device/vs/RespiratoryRateSettingVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/device/vs/#RespiratoryRateSettingVS'" />    
+</head>

--- a/shr/encounter/cs/EpisodeOfCareCompletionCS/index.html
+++ b/shr/encounter/cs/EpisodeOfCareCompletionCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/cs/#EpisodeOfCareCompletionCS'" />    
+</head>

--- a/shr/encounter/cs/ReasonEncounterDidNotHappenCS/index.html
+++ b/shr/encounter/cs/ReasonEncounterDidNotHappenCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/cs/#ReasonEncounterDidNotHappenCS'" />    
+</head>

--- a/shr/encounter/cs/ReferralSourceTypeCS/index.html
+++ b/shr/encounter/cs/ReferralSourceTypeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/cs/#ReferralSourceTypeCS'" />    
+</head>

--- a/shr/encounter/cs/TreatmentCooperationCS/index.html
+++ b/shr/encounter/cs/TreatmentCooperationCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/cs/#TreatmentCooperationCS'" />    
+</head>

--- a/shr/encounter/vs/EncounterUrgencyVS/index.html
+++ b/shr/encounter/vs/EncounterUrgencyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/vs/#EncounterUrgencyVS'" />    
+</head>

--- a/shr/encounter/vs/EpisodeOfCareCompletionVS/index.html
+++ b/shr/encounter/vs/EpisodeOfCareCompletionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/vs/#EpisodeOfCareCompletionVS'" />    
+</head>

--- a/shr/encounter/vs/ReasonEncounterDidNotHappenVS/index.html
+++ b/shr/encounter/vs/ReasonEncounterDidNotHappenVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/vs/#ReasonEncounterDidNotHappenVS'" />    
+</head>

--- a/shr/encounter/vs/ReferralSourceTypeVS/index.html
+++ b/shr/encounter/vs/ReferralSourceTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/vs/#ReferralSourceTypeVS'" />    
+</head>

--- a/shr/encounter/vs/TreatmentCooperationVS/index.html
+++ b/shr/encounter/vs/TreatmentCooperationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/encounter/vs/#TreatmentCooperationVS'" />    
+</head>

--- a/shr/entity/cs/LanguageQualifierCS/index.html
+++ b/shr/entity/cs/LanguageQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/cs/#LanguageQualifierCS'" />    
+</head>

--- a/shr/entity/cs/TelecomQualifierCS/index.html
+++ b/shr/entity/cs/TelecomQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/cs/#TelecomQualifierCS'" />    
+</head>

--- a/shr/entity/vs/AgeGroupVS/index.html
+++ b/shr/entity/vs/AgeGroupVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/vs/#AgeGroupVS'" />    
+</head>

--- a/shr/entity/vs/HealthcareRoleVS/index.html
+++ b/shr/entity/vs/HealthcareRoleVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/vs/#HealthcareRoleVS'" />    
+</head>

--- a/shr/entity/vs/LanguageQualifierVS/index.html
+++ b/shr/entity/vs/LanguageQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/vs/#LanguageQualifierVS'" />    
+</head>

--- a/shr/entity/vs/TelecomQualifierVS/index.html
+++ b/shr/entity/vs/TelecomQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/entity/vs/#TelecomQualifierVS'" />    
+</head>

--- a/shr/environment/cs/CoinhabitantCS/index.html
+++ b/shr/environment/cs/CoinhabitantCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#CoinhabitantCS'" />    
+</head>

--- a/shr/environment/cs/CommonAnimalCS/index.html
+++ b/shr/environment/cs/CommonAnimalCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#CommonAnimalCS'" />    
+</head>

--- a/shr/environment/cs/ExposureReasonCS/index.html
+++ b/shr/environment/cs/ExposureReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#ExposureReasonCS'" />    
+</head>

--- a/shr/environment/cs/HomeEnvironmentRiskCS/index.html
+++ b/shr/environment/cs/HomeEnvironmentRiskCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#HomeEnvironmentRiskCS'" />    
+</head>

--- a/shr/environment/cs/IncomeSourceCS/index.html
+++ b/shr/environment/cs/IncomeSourceCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#IncomeSourceCS'" />    
+</head>

--- a/shr/environment/cs/NonCashBenefitCS/index.html
+++ b/shr/environment/cs/NonCashBenefitCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#NonCashBenefitCS'" />    
+</head>

--- a/shr/environment/cs/ResourceStabilityCS/index.html
+++ b/shr/environment/cs/ResourceStabilityCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/cs/#ResourceStabilityCS'" />    
+</head>

--- a/shr/environment/vs/CoinhabitantVS/index.html
+++ b/shr/environment/vs/CoinhabitantVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#CoinhabitantVS'" />    
+</head>

--- a/shr/environment/vs/CommonAnimalVS/index.html
+++ b/shr/environment/vs/CommonAnimalVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#CommonAnimalVS'" />    
+</head>

--- a/shr/environment/vs/ExposureReasonVS/index.html
+++ b/shr/environment/vs/ExposureReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#ExposureReasonVS'" />    
+</head>

--- a/shr/environment/vs/HomeEnvironmentRiskVS/index.html
+++ b/shr/environment/vs/HomeEnvironmentRiskVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#HomeEnvironmentRiskVS'" />    
+</head>

--- a/shr/environment/vs/IncomeSourceVS/index.html
+++ b/shr/environment/vs/IncomeSourceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#IncomeSourceVS'" />    
+</head>

--- a/shr/environment/vs/NonCashBenefitVS/index.html
+++ b/shr/environment/vs/NonCashBenefitVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#NonCashBenefitVS'" />    
+</head>

--- a/shr/environment/vs/ResourceStabilityVS/index.html
+++ b/shr/environment/vs/ResourceStabilityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/environment/vs/#ResourceStabilityVS'" />    
+</head>

--- a/shr/financial/cs/InsuranceProviderTypeCS/index.html
+++ b/shr/financial/cs/InsuranceProviderTypeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/financial/cs/#InsuranceProviderTypeCS'" />    
+</head>

--- a/shr/financial/vs/InsuranceProviderTypeVS/index.html
+++ b/shr/financial/vs/InsuranceProviderTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/financial/vs/#InsuranceProviderTypeVS'" />    
+</head>

--- a/shr/finding/cs/ValueAbsentReasonCS/index.html
+++ b/shr/finding/cs/ValueAbsentReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/finding/cs/#ValueAbsentReasonCS'" />    
+</head>

--- a/shr/finding/vs/ObservationResultVS/index.html
+++ b/shr/finding/vs/ObservationResultVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/finding/vs/#ObservationResultVS'" />    
+</head>

--- a/shr/finding/vs/ValueAbsentReasonVS/index.html
+++ b/shr/finding/vs/ValueAbsentReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/finding/vs/#ValueAbsentReasonVS'" />    
+</head>

--- a/shr/immunization/vs/ImmunizationNotGivenReasonVS/index.html
+++ b/shr/immunization/vs/ImmunizationNotGivenReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/immunization/vs/#ImmunizationNotGivenReasonVS'" />    
+</head>

--- a/shr/lifehistory/cs/EducationalAttainmentCS/index.html
+++ b/shr/lifehistory/cs/EducationalAttainmentCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#EducationalAttainmentCS'" />    
+</head>

--- a/shr/lifehistory/cs/EmploymentStatusCS/index.html
+++ b/shr/lifehistory/cs/EmploymentStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#EmploymentStatusCS'" />    
+</head>

--- a/shr/lifehistory/cs/MilitaryServiceDischargeStatusCS/index.html
+++ b/shr/lifehistory/cs/MilitaryServiceDischargeStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#MilitaryServiceDischargeStatusCS'" />    
+</head>

--- a/shr/lifehistory/cs/MilitaryServiceEraCS/index.html
+++ b/shr/lifehistory/cs/MilitaryServiceEraCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#MilitaryServiceEraCS'" />    
+</head>

--- a/shr/lifehistory/cs/MilitaryStatusCS/index.html
+++ b/shr/lifehistory/cs/MilitaryStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#MilitaryStatusCS'" />    
+</head>

--- a/shr/lifehistory/cs/TeratogenCS/index.html
+++ b/shr/lifehistory/cs/TeratogenCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#TeratogenCS'" />    
+</head>

--- a/shr/lifehistory/cs/USMilitaryBranchCS/index.html
+++ b/shr/lifehistory/cs/USMilitaryBranchCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/cs/#USMilitaryBranchCS'" />    
+</head>

--- a/shr/lifehistory/vs/CongenitalAbnormalitiesVS/index.html
+++ b/shr/lifehistory/vs/CongenitalAbnormalitiesVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#CongenitalAbnormalitiesVS'" />    
+</head>

--- a/shr/lifehistory/vs/EducationalAttainmentVS/index.html
+++ b/shr/lifehistory/vs/EducationalAttainmentVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#EducationalAttainmentVS'" />    
+</head>

--- a/shr/lifehistory/vs/EmploymentStatusVS/index.html
+++ b/shr/lifehistory/vs/EmploymentStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#EmploymentStatusVS'" />    
+</head>

--- a/shr/lifehistory/vs/MilitaryServiceDischargeStatusVS/index.html
+++ b/shr/lifehistory/vs/MilitaryServiceDischargeStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#MilitaryServiceDischargeStatusVS'" />    
+</head>

--- a/shr/lifehistory/vs/MilitaryServiceEraVS/index.html
+++ b/shr/lifehistory/vs/MilitaryServiceEraVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#MilitaryServiceEraVS'" />    
+</head>

--- a/shr/lifehistory/vs/MilitaryStatusVS/index.html
+++ b/shr/lifehistory/vs/MilitaryStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#MilitaryStatusVS'" />    
+</head>

--- a/shr/lifehistory/vs/TeratogenVS/index.html
+++ b/shr/lifehistory/vs/TeratogenVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#TeratogenVS'" />    
+</head>

--- a/shr/lifehistory/vs/USMilitaryBranchVS/index.html
+++ b/shr/lifehistory/vs/USMilitaryBranchVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/lifehistory/vs/#USMilitaryBranchVS'" />    
+</head>

--- a/shr/medication/cs/MedicationChangeReasonCS/index.html
+++ b/shr/medication/cs/MedicationChangeReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/cs/#MedicationChangeReasonCS'" />    
+</head>

--- a/shr/medication/cs/MedicationChangeTypeCS/index.html
+++ b/shr/medication/cs/MedicationChangeTypeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/cs/#MedicationChangeTypeCS'" />    
+</head>

--- a/shr/medication/cs/MedicationNotUsedReasonCS/index.html
+++ b/shr/medication/cs/MedicationNotUsedReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/cs/#MedicationNotUsedReasonCS'" />    
+</head>

--- a/shr/medication/vs/MedicationChangeReasonVS/index.html
+++ b/shr/medication/vs/MedicationChangeReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/vs/#MedicationChangeReasonVS'" />    
+</head>

--- a/shr/medication/vs/MedicationChangeTypeVS/index.html
+++ b/shr/medication/vs/MedicationChangeTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/vs/#MedicationChangeTypeVS'" />    
+</head>

--- a/shr/medication/vs/MedicationNonAdherenceReasonVS/index.html
+++ b/shr/medication/vs/MedicationNonAdherenceReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/vs/#MedicationNonAdherenceReasonVS'" />    
+</head>

--- a/shr/medication/vs/MedicationNotUsedReasonVS/index.html
+++ b/shr/medication/vs/MedicationNotUsedReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/medication/vs/#MedicationNotUsedReasonVS'" />    
+</head>

--- a/shr/oncology/cs/BrcaReceptorStatusCS/index.html
+++ b/shr/oncology/cs/BrcaReceptorStatusCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#BrcaReceptorStatusCS'" />    
+</head>

--- a/shr/oncology/cs/DecileCS/index.html
+++ b/shr/oncology/cs/DecileCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#DecileCS'" />    
+</head>

--- a/shr/oncology/cs/DegreeOfLymphaticInvolvementCS/index.html
+++ b/shr/oncology/cs/DegreeOfLymphaticInvolvementCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#DegreeOfLymphaticInvolvementCS'" />    
+</head>

--- a/shr/oncology/cs/HER2MethodCS/index.html
+++ b/shr/oncology/cs/HER2MethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#HER2MethodCS'" />    
+</head>

--- a/shr/oncology/cs/StagingMethodCS/index.html
+++ b/shr/oncology/cs/StagingMethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#StagingMethodCS'" />    
+</head>

--- a/shr/oncology/cs/StagingTimeCS/index.html
+++ b/shr/oncology/cs/StagingTimeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/cs/#StagingTimeCS'" />    
+</head>

--- a/shr/oncology/vs/BrcaReceptorStatusVS/index.html
+++ b/shr/oncology/vs/BrcaReceptorStatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#BrcaReceptorStatusVS'" />    
+</head>

--- a/shr/oncology/vs/BreastCancerTypeVS/index.html
+++ b/shr/oncology/vs/BreastCancerTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#BreastCancerTypeVS'" />    
+</head>

--- a/shr/oncology/vs/CertifiedByVS/index.html
+++ b/shr/oncology/vs/CertifiedByVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#CertifiedByVS'" />    
+</head>

--- a/shr/oncology/vs/DecileVS/index.html
+++ b/shr/oncology/vs/DecileVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#DecileVS'" />    
+</head>

--- a/shr/oncology/vs/DegreeOfLymphaticInvolvementVS/index.html
+++ b/shr/oncology/vs/DegreeOfLymphaticInvolvementVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#DegreeOfLymphaticInvolvementVS'" />    
+</head>

--- a/shr/oncology/vs/EstrogenAntibodyVS/index.html
+++ b/shr/oncology/vs/EstrogenAntibodyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#EstrogenAntibodyVS'" />    
+</head>

--- a/shr/oncology/vs/GeneIdentifierVS/index.html
+++ b/shr/oncology/vs/GeneIdentifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#GeneIdentifierVS'" />    
+</head>

--- a/shr/oncology/vs/HER2AntibodyIHCVS/index.html
+++ b/shr/oncology/vs/HER2AntibodyIHCVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#HER2AntibodyIHCVS'" />    
+</head>

--- a/shr/oncology/vs/HER2MethodVS/index.html
+++ b/shr/oncology/vs/HER2MethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#HER2MethodVS'" />    
+</head>

--- a/shr/oncology/vs/HER2StatusVS/index.html
+++ b/shr/oncology/vs/HER2StatusVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#HER2StatusVS'" />    
+</head>

--- a/shr/oncology/vs/Ki67AntibodyVS/index.html
+++ b/shr/oncology/vs/Ki67AntibodyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#Ki67AntibodyVS'" />    
+</head>

--- a/shr/oncology/vs/LymphSystemSubdivisionVS/index.html
+++ b/shr/oncology/vs/LymphSystemSubdivisionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#LymphSystemSubdivisionVS'" />    
+</head>

--- a/shr/oncology/vs/NeoplasmObservationMethodVS/index.html
+++ b/shr/oncology/vs/NeoplasmObservationMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#NeoplasmObservationMethodVS'" />    
+</head>

--- a/shr/oncology/vs/NeoplasmObservationVS/index.html
+++ b/shr/oncology/vs/NeoplasmObservationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#NeoplasmObservationVS'" />    
+</head>

--- a/shr/oncology/vs/NottinghamCombinedGradeVS/index.html
+++ b/shr/oncology/vs/NottinghamCombinedGradeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#NottinghamCombinedGradeVS'" />    
+</head>

--- a/shr/oncology/vs/NuclearPleomorphismScoreVS/index.html
+++ b/shr/oncology/vs/NuclearPleomorphismScoreVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#NuclearPleomorphismScoreVS'" />    
+</head>

--- a/shr/oncology/vs/ProgesteroneAntibodyVS/index.html
+++ b/shr/oncology/vs/ProgesteroneAntibodyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#ProgesteroneAntibodyVS'" />    
+</head>

--- a/shr/oncology/vs/ReceptorVS/index.html
+++ b/shr/oncology/vs/ReceptorVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#ReceptorVS'" />    
+</head>

--- a/shr/oncology/vs/RefseqVS/index.html
+++ b/shr/oncology/vs/RefseqVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#RefseqVS'" />    
+</head>

--- a/shr/oncology/vs/StagingMethodVS/index.html
+++ b/shr/oncology/vs/StagingMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#StagingMethodVS'" />    
+</head>

--- a/shr/oncology/vs/StagingTimeVS/index.html
+++ b/shr/oncology/vs/StagingTimeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#StagingTimeVS'" />    
+</head>

--- a/shr/oncology/vs/StainingControlVS/index.html
+++ b/shr/oncology/vs/StainingControlVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#StainingControlVS'" />    
+</head>

--- a/shr/oncology/vs/StainingIntensityVS/index.html
+++ b/shr/oncology/vs/StainingIntensityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#StainingIntensityVS'" />    
+</head>

--- a/shr/oncology/vs/TubuleFormationScoreVS/index.html
+++ b/shr/oncology/vs/TubuleFormationScoreVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#TubuleFormationScoreVS'" />    
+</head>

--- a/shr/oncology/vs/TumorMarginDescriptionVS/index.html
+++ b/shr/oncology/vs/TumorMarginDescriptionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/oncology/vs/#TumorMarginDescriptionVS'" />    
+</head>

--- a/shr/procedure/vs/ChangeFlagVS/index.html
+++ b/shr/procedure/vs/ChangeFlagVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#ChangeFlagVS'" />    
+</head>

--- a/shr/procedure/vs/HIVScreeningTestCodeVS/index.html
+++ b/shr/procedure/vs/HIVScreeningTestCodeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#HIVScreeningTestCodeVS'" />    
+</head>

--- a/shr/procedure/vs/HIVScreeningTestResultVS/index.html
+++ b/shr/procedure/vs/HIVScreeningTestResultVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#HIVScreeningTestResultVS'" />    
+</head>

--- a/shr/procedure/vs/HIVSupplementalTestCodeVS/index.html
+++ b/shr/procedure/vs/HIVSupplementalTestCodeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#HIVSupplementalTestCodeVS'" />    
+</head>

--- a/shr/procedure/vs/HIVSupplementalTestResultVS/index.html
+++ b/shr/procedure/vs/HIVSupplementalTestResultVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#HIVSupplementalTestResultVS'" />    
+</head>

--- a/shr/procedure/vs/PositiveNegativeIndeterminateVS/index.html
+++ b/shr/procedure/vs/PositiveNegativeIndeterminateVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/procedure/vs/#PositiveNegativeIndeterminateVS'" />    
+</head>

--- a/shr/research/cs/ResearchSubjectTerminationReasonCS/index.html
+++ b/shr/research/cs/ResearchSubjectTerminationReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/research/cs/#ResearchSubjectTerminationReasonCS'" />    
+</head>

--- a/shr/research/cs/StudyArmTypeCS/index.html
+++ b/shr/research/cs/StudyArmTypeCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/research/cs/#StudyArmTypeCS'" />    
+</head>

--- a/shr/research/vs/ResearchSubjectTerminationReasonVS/index.html
+++ b/shr/research/vs/ResearchSubjectTerminationReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/research/vs/#ResearchSubjectTerminationReasonVS'" />    
+</head>

--- a/shr/research/vs/StudyArmTypeVS/index.html
+++ b/shr/research/vs/StudyArmTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/research/vs/#StudyArmTypeVS'" />    
+</head>

--- a/shr/sex/cs/ContraceptiveMethodCS/index.html
+++ b/shr/sex/cs/ContraceptiveMethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/cs/#ContraceptiveMethodCS'" />    
+</head>

--- a/shr/sex/cs/ContraceptiveMethodReasonCS/index.html
+++ b/shr/sex/cs/ContraceptiveMethodReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/cs/#ContraceptiveMethodReasonCS'" />    
+</head>

--- a/shr/sex/cs/ContraceptiveNotUsedReasonCS/index.html
+++ b/shr/sex/cs/ContraceptiveNotUsedReasonCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/cs/#ContraceptiveNotUsedReasonCS'" />    
+</head>

--- a/shr/sex/cs/GenderIdentityCS/index.html
+++ b/shr/sex/cs/GenderIdentityCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/cs/#GenderIdentityCS'" />    
+</head>

--- a/shr/sex/vs/CommonPregnancyComplicationVS/index.html
+++ b/shr/sex/vs/CommonPregnancyComplicationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#CommonPregnancyComplicationVS'" />    
+</head>

--- a/shr/sex/vs/ContraceptiveMethodReasonVS/index.html
+++ b/shr/sex/vs/ContraceptiveMethodReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#ContraceptiveMethodReasonVS'" />    
+</head>

--- a/shr/sex/vs/ContraceptiveMethodVS/index.html
+++ b/shr/sex/vs/ContraceptiveMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#ContraceptiveMethodVS'" />    
+</head>

--- a/shr/sex/vs/ContraceptiveNotUsedReasonVS/index.html
+++ b/shr/sex/vs/ContraceptiveNotUsedReasonVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#ContraceptiveNotUsedReasonVS'" />    
+</head>

--- a/shr/sex/vs/GenderIdentityVS/index.html
+++ b/shr/sex/vs/GenderIdentityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#GenderIdentityVS'" />    
+</head>

--- a/shr/sex/vs/IntercourseDifficultyVS/index.html
+++ b/shr/sex/vs/IntercourseDifficultyVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#IntercourseDifficultyVS'" />    
+</head>

--- a/shr/sex/vs/SexualActivityVS/index.html
+++ b/shr/sex/vs/SexualActivityVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#SexualActivityVS'" />    
+</head>

--- a/shr/sex/vs/SexualOrientationVS/index.html
+++ b/shr/sex/vs/SexualOrientationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/sex/vs/#SexualOrientationVS'" />    
+</head>

--- a/shr/skin/cs/SupportSurfaceBodyPositionCS/index.html
+++ b/shr/skin/cs/SupportSurfaceBodyPositionCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/cs/#SupportSurfaceBodyPositionCS'" />    
+</head>

--- a/shr/skin/cs/SupportSurfaceCategoryCS/index.html
+++ b/shr/skin/cs/SupportSurfaceCategoryCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/cs/#SupportSurfaceCategoryCS'" />    
+</head>

--- a/shr/skin/cs/SupportSurfaceComponentCS/index.html
+++ b/shr/skin/cs/SupportSurfaceComponentCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/cs/#SupportSurfaceComponentCS'" />    
+</head>

--- a/shr/skin/cs/SupportSurfaceFeatureCS/index.html
+++ b/shr/skin/cs/SupportSurfaceFeatureCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/cs/#SupportSurfaceFeatureCS'" />    
+</head>

--- a/shr/skin/cs/WoundAssociationCS/index.html
+++ b/shr/skin/cs/WoundAssociationCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/cs/#WoundAssociationCS'" />    
+</head>

--- a/shr/skin/vs/SupportSurfaceBodyPositionVS/index.html
+++ b/shr/skin/vs/SupportSurfaceBodyPositionVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#SupportSurfaceBodyPositionVS'" />    
+</head>

--- a/shr/skin/vs/SupportSurfaceCategoryVS/index.html
+++ b/shr/skin/vs/SupportSurfaceCategoryVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#SupportSurfaceCategoryVS'" />    
+</head>

--- a/shr/skin/vs/SupportSurfaceComponentVS/index.html
+++ b/shr/skin/vs/SupportSurfaceComponentVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#SupportSurfaceComponentVS'" />    
+</head>

--- a/shr/skin/vs/SupportSurfaceFeatureVS/index.html
+++ b/shr/skin/vs/SupportSurfaceFeatureVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#SupportSurfaceFeatureVS'" />    
+</head>

--- a/shr/skin/vs/SupportSurfaceVS/index.html
+++ b/shr/skin/vs/SupportSurfaceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#SupportSurfaceVS'" />    
+</head>

--- a/shr/skin/vs/VisibleInternalStructureVS/index.html
+++ b/shr/skin/vs/VisibleInternalStructureVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#VisibleInternalStructureVS'" />    
+</head>

--- a/shr/skin/vs/WoundAssociationVS/index.html
+++ b/shr/skin/vs/WoundAssociationVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#WoundAssociationVS'" />    
+</head>

--- a/shr/skin/vs/WoundBodySiteVS/index.html
+++ b/shr/skin/vs/WoundBodySiteVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#WoundBodySiteVS'" />    
+</head>

--- a/shr/skin/vs/WoundEdgeAppearanceVS/index.html
+++ b/shr/skin/vs/WoundEdgeAppearanceVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#WoundEdgeAppearanceVS'" />    
+</head>

--- a/shr/skin/vs/WoundTypeVS/index.html
+++ b/shr/skin/vs/WoundTypeVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/skin/vs/#WoundTypeVS'" />    
+</head>

--- a/shr/vital/cs/BloodPressureMethodCS/index.html
+++ b/shr/vital/cs/BloodPressureMethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#BloodPressureMethodCS'" />    
+</head>

--- a/shr/vital/cs/BloodPressureQualifierCS/index.html
+++ b/shr/vital/cs/BloodPressureQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#BloodPressureQualifierCS'" />    
+</head>

--- a/shr/vital/cs/BodyHeightQualifierCS/index.html
+++ b/shr/vital/cs/BodyHeightQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#BodyHeightQualifierCS'" />    
+</head>

--- a/shr/vital/cs/BodyTemperatureQualifierCS/index.html
+++ b/shr/vital/cs/BodyTemperatureQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#BodyTemperatureQualifierCS'" />    
+</head>

--- a/shr/vital/cs/BodyWeightQualifierCS/index.html
+++ b/shr/vital/cs/BodyWeightQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#BodyWeightQualifierCS'" />    
+</head>

--- a/shr/vital/cs/HeartRateMethodCS/index.html
+++ b/shr/vital/cs/HeartRateMethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#HeartRateMethodCS'" />    
+</head>

--- a/shr/vital/cs/HeartRateQualifierCS/index.html
+++ b/shr/vital/cs/HeartRateQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#HeartRateQualifierCS'" />    
+</head>

--- a/shr/vital/cs/RespiratoryRateMethodCS/index.html
+++ b/shr/vital/cs/RespiratoryRateMethodCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#RespiratoryRateMethodCS'" />    
+</head>

--- a/shr/vital/cs/RespiratoryRateQualifierCS/index.html
+++ b/shr/vital/cs/RespiratoryRateQualifierCS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/cs/#RespiratoryRateQualifierCS'" />    
+</head>

--- a/shr/vital/vs/BloodPressureBodySiteVS/index.html
+++ b/shr/vital/vs/BloodPressureBodySiteVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BloodPressureBodySiteVS'" />    
+</head>

--- a/shr/vital/vs/BloodPressureMethodVS/index.html
+++ b/shr/vital/vs/BloodPressureMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BloodPressureMethodVS'" />    
+</head>

--- a/shr/vital/vs/BloodPressureQualifierVS/index.html
+++ b/shr/vital/vs/BloodPressureQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BloodPressureQualifierVS'" />    
+</head>

--- a/shr/vital/vs/BodyHeightQualifierVS/index.html
+++ b/shr/vital/vs/BodyHeightQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BodyHeightQualifierVS'" />    
+</head>

--- a/shr/vital/vs/BodyTemperatureBodySiteVS/index.html
+++ b/shr/vital/vs/BodyTemperatureBodySiteVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BodyTemperatureBodySiteVS'" />    
+</head>

--- a/shr/vital/vs/BodyTemperatureQualifierVS/index.html
+++ b/shr/vital/vs/BodyTemperatureQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BodyTemperatureQualifierVS'" />    
+</head>

--- a/shr/vital/vs/BodyWeightQualifierVS/index.html
+++ b/shr/vital/vs/BodyWeightQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#BodyWeightQualifierVS'" />    
+</head>

--- a/shr/vital/vs/HeartRateMethodVS/index.html
+++ b/shr/vital/vs/HeartRateMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#HeartRateMethodVS'" />    
+</head>

--- a/shr/vital/vs/HeartRateQualifierVS/index.html
+++ b/shr/vital/vs/HeartRateQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#HeartRateQualifierVS'" />    
+</head>

--- a/shr/vital/vs/OxygenSaturationBodySiteVS/index.html
+++ b/shr/vital/vs/OxygenSaturationBodySiteVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#OxygenSaturationBodySiteVS'" />    
+</head>

--- a/shr/vital/vs/RespiratoryRateMethodVS/index.html
+++ b/shr/vital/vs/RespiratoryRateMethodVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#RespiratoryRateMethodVS'" />    
+</head>

--- a/shr/vital/vs/RespiratoryRateQualifierVS/index.html
+++ b/shr/vital/vs/RespiratoryRateQualifierVS/index.html
@@ -1,0 +1,3 @@
+<head>
+    <meta http-equiv="refresh" content="0; URL='http://standardhealthrecord.org/shr/vital/vs/#RespiratoryRateQualifierVS'" />    
+</head>


### PR DESCRIPTION
This resolves the mismatch between value set and code system url’s that
are missing # anchor tags, and the valid urls that do have them. By
creating redirects from the anchor tag-less pages to the properly
anchor-tagged page, both URL’s become valid references to a VS/CS.

e.g.
valid url: http://standardhealthrecord.org/shr/adverse/vs/#MedDRAVS
previously invalid but now redirected url: http://standardhealthrecord.org/shr/adverse/vs/MedDRAVS

Test:
https://abhijay.github.io/shr/environment/vs/#HomeEnvironmentRiskVS
compared to: https://abhijay.github.io/shr/environment/vs/HomeEnvironmentRiskVS

Generated through: https://github.com/standardhealth/spec_json2html/pull/15
